### PR TITLE
Add API documentation (OpenAPI + Swagger + API.md)

### DIFF
--- a/services/projects/README.md
+++ b/services/projects/README.md
@@ -62,6 +62,13 @@ http://localhost:5000
 
 ---
 
+
+## Service API Docs
+
+http://localhost:5000/docs
+
+---
+
 ## Health Checks
 
 ### Service health

--- a/services/projects/app/extensions.py
+++ b/services/projects/app/extensions.py
@@ -1,5 +1,7 @@
 from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
+from flask_smorest import Api
 
 db = SQLAlchemy()
 migrate = Migrate()
+api = Api()

--- a/services/projects/app/main.py
+++ b/services/projects/app/main.py
@@ -2,10 +2,13 @@ import os
 
 from flask import Flask
 
-from app.extensions import db, migrate
+from app.extensions import api, db, migrate
 from app.routes import routes
 
 
+# -------------------------------------------------------------------------------------------------
+# Database configuration
+# -------------------------------------------------------------------------------------------------
 def _build_db_uri():
     """Build the SQLAlchemy database URI from environment variables.
 
@@ -20,6 +23,29 @@ def _build_db_uri():
     return f"postgresql://{db_user}:{db_password}@{db_host}:{db_port}/{db_name}"
 
 
+# -------------------------------------------------------------------------------------------------
+# Application configuration
+# -------------------------------------------------------------------------------------------------
+def _configure_app(app):
+    """Configure Flask, database, and OpenAPI settings.
+
+    param app: Flask application instance.
+    return: None.
+    """
+    app.config["SQLALCHEMY_DATABASE_URI"] = _build_db_uri()
+    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+
+    app.config["API_TITLE"] = "Projects Service API"
+    app.config["API_VERSION"] = "v1"
+    app.config["OPENAPI_VERSION"] = "3.0.3"
+    app.config["OPENAPI_URL_PREFIX"] = "/"
+    app.config["OPENAPI_SWAGGER_UI_PATH"] = "/docs"
+    app.config["OPENAPI_SWAGGER_UI_URL"] = "https://cdn.jsdelivr.net/npm/swagger-ui-dist/"
+
+
+# -------------------------------------------------------------------------------------------------
+# Extension initialisation
+# -------------------------------------------------------------------------------------------------
 def _init_extensions(app):
     """Initialise Flask extensions.
 
@@ -30,6 +56,20 @@ def _init_extensions(app):
     migrate.init_app(app, db)
 
 
+# -------------------------------------------------------------------------------------------------
+# Blueprint registration
+# -------------------------------------------------------------------------------------------------
+def _register_blueprints():
+    """Register Flask-Smorest blueprints.
+
+    return: None.
+    """
+    api.register_blueprint(routes, url_prefix="/api")
+
+
+# -------------------------------------------------------------------------------------------------
+# Application factory
+# -------------------------------------------------------------------------------------------------
 def create_app():
     """Create and configure the Flask application.
 
@@ -37,11 +77,10 @@ def create_app():
     """
     app = Flask(__name__)
 
-    app.config["SQLALCHEMY_DATABASE_URI"] = _build_db_uri()
-    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
-
+    _configure_app(app)
     _init_extensions(app)
 
-    app.register_blueprint(routes)
+    api.init_app(app)
+    _register_blueprints()
 
     return app

--- a/services/projects/app/open_api_docs.py
+++ b/services/projects/app/open_api_docs.py
@@ -1,0 +1,52 @@
+from flask_smorest import Blueprint
+
+from app.schemas import ErrorSchema
+
+USER_ID_HEADER = {
+    "in": "header",
+    "name": "X-User-ID",
+    "schema": {"type": "string"},
+    "required": True,
+    "description": "User ID supplied by the Django BFF.",
+}
+
+
+def endpoint_docs(routes: Blueprint, *, success_code=200, response_schema=None, errors=(400,)):
+    """Apply standardised OpenAPI documentation to a route function.
+
+    This decorator consolidates common documentation concerns including:
+    - Required X-User-ID header
+    - Success response schema and status code
+    - Standardised error responses
+
+    It wraps multiple flask-smorest decorators into a single reusable helper
+    to keep route definitions concise and consistent.
+
+    Example:
+        @routes.get("/projects")
+        @endpoint_docs(routes, response_schema=ProjectResultsSchema)
+        def get_projects():
+            ...
+
+    param routes: The Flask-Smorest Blueprint used to register documentation.
+    param success_code: HTTP status code for the successful response (default: 200).
+    param response_schema: Marshmallow schema for the success response. If None, no schema is applied.
+    param errors: Iterable of HTTP status codes to document using the ErrorSchema.
+
+    return: A decorator that applies the configured documentation to the route function.
+    """
+
+    def decorator(fn):
+        fn = routes.doc(parameters=[USER_ID_HEADER])(fn)
+
+        if response_schema is not None:
+            fn = routes.response(success_code, response_schema)(fn)
+        else:
+            fn = routes.response(success_code)(fn)
+
+        for status_code in reversed(errors):
+            fn = routes.alt_response(status_code, schema=ErrorSchema)(fn)
+
+        return fn
+
+    return decorator

--- a/services/projects/app/routes.py
+++ b/services/projects/app/routes.py
@@ -1,26 +1,53 @@
-from flask import Blueprint, request
+from flask import request
+from flask_smorest import Blueprint, abort
 
+from app.open_api_docs import endpoint_docs
 from app.extensions import db
 from app.models import Project
+from app.schemas import (
+    ProjectCreateSchema,
+    ProjectResultsSchema,
+    ProjectUpdateSchema,
+)
 
-routes = Blueprint("routes", __name__)
+routes = Blueprint("routes", __name__, description="Projects service endpoints")
 
 
+# ---------------------------------------------------------------------------------------------------------------------
+# Helper functions for route handlers
+# ---------------------------------------------------------------------------------------------------------------------
+def get_required_user_id():
+    """Return the authenticated user ID."""
+    user_id = request.headers.get("X-User-ID")
+
+    if not user_id:
+        abort(400, message="Missing X-User-ID header")
+
+    return user_id
+
+
+def get_owned_project_or_error(project_id, user_id):
+    """Return a project owned by the authenticated user."""
+    project = Project.query.filter_by(id=project_id, owner_user_id=user_id).first()
+
+    if not project:
+        abort(404, message="Project not found")
+
+    return project
+
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Route handlers
+# ---------------------------------------------------------------------------------------------------------------------
 @routes.get("/health")
 def health():
-    """Return basic service health status.
-
-    return: JSON health response and HTTP status code.
-    """
+    """Return a basic service health check."""
     return {"status": "ok"}, 200
 
 
 @routes.get("/db-health")
 def db_health():
-    """Check the database connection.
-
-    return: JSON database health response and HTTP status code.
-    """
+    """Return a database connectivity health check."""
     with db.engine.connect() as connection:
         connection.exec_driver_sql("SELECT 1")
 
@@ -28,20 +55,12 @@ def db_health():
 
 
 @routes.post("/projects")
-def create_project():
-    """Create a new project.
-
-    return: Created project response and HTTP status code.
-    """
-    data = request.get_json() or {}
-
-    user_id = request.headers.get("X-User-ID")
-    if not user_id:
-        return {"error": "Missing X-User-ID header"}, 400
-
+@routes.arguments(ProjectCreateSchema)
+@endpoint_docs(routes, success_code=201, response_schema=ProjectResultsSchema)
+def create_project(data):
+    """Create a new project for the authenticated user."""
+    user_id = get_required_user_id()
     project = Project(owner_user_id=user_id, name=data.get("name"), description=data.get("description"))
-    if not project.name:
-        return {"error": "Missing project name"}, 400
 
     db.session.add(project)
     db.session.commit()
@@ -50,54 +69,33 @@ def create_project():
 
 
 @routes.get("/projects")
+@endpoint_docs(routes, response_schema=ProjectResultsSchema)
 def get_all_projects():
-    """Get all projects for the authenticated user.
-
-    return: List of projects and HTTP status code.
-    """
-    user_id = request.headers.get("X-User-ID")
-    if not user_id:
-        return {"error": "Missing X-User-ID header"}, 400
-
+    """Return all projects owned by the authenticated user."""
+    user_id = get_required_user_id()
     projects = Project.query.filter_by(owner_user_id=user_id).all()
 
     return {"results": [project.to_dict() for project in projects]}, 200
 
 
 @routes.get("/projects/<int:project_id>")
+@endpoint_docs(routes, response_schema=ProjectResultsSchema, errors=(400, 404))
 def get_project_detail(project_id):
-    """Get a single project for the authenticated user.
-
-    param project_id: ID of the project.
-    return: Project detail and HTTP status code.
-    """
-    user_id = request.headers.get("X-User-ID")
-    if not user_id:
-        return {"error": "Missing X-User-ID header"}, 400
-
-    project = Project.query.filter_by(id=project_id, owner_user_id=user_id).first()
-    if not project:
-        return {"error": "Project not found"}, 404
+    """Return a single project owned by the authenticated user."""
+    user_id = get_required_user_id()
+    project = get_owned_project_or_error(project_id, user_id)
 
     return {"results": [project.to_dict()]}, 200
 
 
 @routes.patch("/projects/<int:project_id>")
-def update_project(project_id):
-    """Update a project for the authenticated user.
+@routes.arguments(ProjectUpdateSchema)
+@endpoint_docs(routes, response_schema=ProjectResultsSchema, errors=(400, 404))
+def update_project(data, project_id):
+    """Update a project owned by the authenticated user."""
+    user_id = get_required_user_id()
+    project = get_owned_project_or_error(project_id, user_id)
 
-    param project_id: ID of the project.
-    return: Updated project detail and HTTP status code.
-    """
-    user_id = request.headers.get("X-User-ID")
-    if not user_id:
-        return {"error": "Missing X-User-ID header"}, 400
-
-    project = Project.query.filter_by(id=project_id, owner_user_id=user_id).first()
-    if not project:
-        return {"error": "Project not found"}, 404
-
-    data = request.get_json() or {}
     project.name = data.get("name", project.name)
     project.description = data.get("description", project.description)
 
@@ -107,21 +105,11 @@ def update_project(project_id):
 
 
 @routes.delete("/projects/<int:project_id>")
+@endpoint_docs(routes, success_code=204, response_schema=None, errors=(400, 404))
 def delete_project(project_id):
-    """Delete a project for the authenticated user.
-
-    param project_id: ID of the project.
-    return: Empty response and HTTP status code.
-    """
-    user_id = request.headers.get("X-User-ID")
-
-    if not user_id:
-        return {"error": "Missing X-User-ID header"}, 400
-
-    project = Project.query.filter_by(id=project_id, owner_user_id=user_id).first()
-
-    if not project:
-        return {"error": "Project not found"}, 404
+    """Delete a project owned by the authenticated user."""
+    user_id = get_required_user_id()
+    project = get_owned_project_or_error(project_id, user_id)
 
     db.session.delete(project)
     db.session.commit()

--- a/services/projects/app/schemas.py
+++ b/services/projects/app/schemas.py
@@ -1,0 +1,89 @@
+from marshmallow import Schema, fields, validates, ValidationError
+
+
+class ProjectCreateSchema(Schema):
+    """Schema for creating a new project.
+
+    This schema validates incoming request data when creating a project.
+    It ensures that required fields are present and conform to expected formats.
+
+    Fields:
+    - name: Project name. Must be a non-empty string.
+    - description: Optional project description. Can be null.
+
+    Validation:
+    - name must not be empty or whitespace-only.
+    """
+
+    name = fields.String(required=True)
+    description = fields.String(allow_none=True)
+
+    @validates("name")
+    def validate_name(self, value, **kwargs):
+        """Validate the project name field.
+
+        param value: The provided project name.
+        return: None.
+        raises ValidationError: If the name is empty or whitespace-only.
+        """
+        if not value.strip():
+            raise ValidationError("Project name is required.")
+
+
+class ProjectUpdateSchema(Schema):
+    """Schema for updating an existing project.
+
+    This schema is used for partial updates (PATCH requests). All fields are optional,
+    but any provided values must conform to expected formats.
+
+    Fields:
+    - name: Optional updated project name.
+    - description: Optional updated project description. Can be null.
+    """
+
+    name = fields.String()
+    description = fields.String(allow_none=True)
+
+
+class ProjectSchema(Schema):
+    """Schema representing a project object in responses.
+
+    This schema defines the structure of a project as returned by the API.
+
+    Fields:
+    - id: Unique project identifier.
+    - owner_user_id: Identifier of the user who owns the project.
+    - name: Project name.
+    - description: Optional project description.
+    """
+
+    id = fields.Integer(required=True)
+    owner_user_id = fields.String(required=True)
+    name = fields.String(required=True)
+    description = fields.String(allow_none=True)
+
+
+class ProjectResultsSchema(Schema):
+    """Schema for wrapping project results in API responses.
+
+    This schema standardises responses that return one or more projects
+    by enclosing them in a "results" list.
+
+    Fields:
+    - results: List of project objects.
+    """
+
+    results = fields.List(fields.Nested(ProjectSchema))
+
+
+class ErrorSchema(Schema):
+    """Schema representing a simple error response.
+
+    This schema defines the structure for custom error responses returned
+    by the API.
+
+    Fields:
+    - error: Error message describing what went wrong.
+    """
+
+    error = fields.String(required=True)

--- a/services/projects/docs/API.md
+++ b/services/projects/docs/API.md
@@ -1,0 +1,43 @@
+# Projects Service API
+
+Version: `v1`
+
+Base URL:
+
+```text
+/api
+```
+
+Swagger UI:
+
+```text
+/docs
+```
+
+## Authentication
+
+Project endpoints require:
+
+```text
+X-User-ID: <user-id>
+```
+
+## Endpoints
+
+| Method | Path | Description | Auth |
+|---|---|---|---|
+| GET | `/api/health` | Return a basic service health check. | No |
+| GET | `/api/db-health` | Return a database connectivity health check. | No |
+| POST | `/api/projects` | Create a new project for the authenticated user. | Yes |
+| GET | `/api/projects` | Return all projects owned by the authenticated user. | Yes |
+| GET | `/api/projects/{project_id}` | Return a single project owned by the authenticated user. | Yes |
+| PATCH | `/api/projects/{project_id}` | Update a project owned by the authenticated user. | Yes |
+| DELETE | `/api/projects/{project_id}` | Delete a project owned by the authenticated user. | Yes |
+
+## Error responses
+
+| Status | Meaning |
+|---|---|
+| 400 | Bad request, such as missing `X-User-ID` |
+| 404 | Resource not found |
+| 422 | Request body validation failed |

--- a/services/projects/docs/openapi.json
+++ b/services/projects/docs/openapi.json
@@ -1,0 +1,475 @@
+{
+  "paths": {
+    "/api/health": {
+      "get": {
+        "responses": {
+          "default": {
+            "$ref": "#/components/responses/DEFAULT_ERROR"
+          }
+        },
+        "summary": "Return a basic service health check.",
+        "tags": [
+          "routes"
+        ]
+      }
+    },
+    "/api/db-health": {
+      "get": {
+        "responses": {
+          "default": {
+            "$ref": "#/components/responses/DEFAULT_ERROR"
+          }
+        },
+        "summary": "Return a database connectivity health check.",
+        "tags": [
+          "routes"
+        ]
+      }
+    },
+    "/api/projects": {
+      "post": {
+        "responses": {
+          "422": {
+            "$ref": "#/components/responses/UNPROCESSABLE_ENTITY"
+          },
+          "201": {
+            "description": "Created",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectResults"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error1"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/DEFAULT_ERROR"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProjectCreate"
+              }
+            }
+          }
+        },
+        "summary": "Create a new project for the authenticated user.",
+        "tags": [
+          "routes"
+        ],
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-User-ID",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "User ID supplied by the Django BFF."
+          }
+        ]
+      },
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectResults"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error1"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/DEFAULT_ERROR"
+          }
+        },
+        "summary": "Return all projects owned by the authenticated user.",
+        "tags": [
+          "routes"
+        ],
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-User-ID",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "User ID supplied by the Django BFF."
+          }
+        ]
+      }
+    },
+    "/api/projects/{project_id}": {
+      "get": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectResults"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error1"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/DEFAULT_ERROR"
+          }
+        },
+        "summary": "Return a single project owned by the authenticated user.",
+        "tags": [
+          "routes"
+        ],
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-User-ID",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "User ID supplied by the Django BFF."
+          }
+        ]
+      },
+      "parameters": [
+        {
+          "in": "path",
+          "name": "project_id",
+          "required": true,
+          "schema": {
+            "type": "integer",
+            "minimum": 0
+          }
+        }
+      ],
+      "patch": {
+        "responses": {
+          "422": {
+            "$ref": "#/components/responses/UNPROCESSABLE_ENTITY"
+          },
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProjectResults"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error1"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/DEFAULT_ERROR"
+          }
+        },
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProjectUpdate"
+              }
+            }
+          }
+        },
+        "summary": "Update a project owned by the authenticated user.",
+        "tags": [
+          "routes"
+        ],
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-User-ID",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "User ID supplied by the Django BFF."
+          }
+        ]
+      },
+      "delete": {
+        "responses": {
+          "204": {
+            "description": "No Content"
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error1"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error1"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/DEFAULT_ERROR"
+          }
+        },
+        "summary": "Delete a project owned by the authenticated user.",
+        "tags": [
+          "routes"
+        ],
+        "parameters": [
+          {
+            "in": "header",
+            "name": "X-User-ID",
+            "schema": {
+              "type": "string"
+            },
+            "required": true,
+            "description": "User ID supplied by the Django BFF."
+          }
+        ]
+      }
+    }
+  },
+  "info": {
+    "title": "Projects Service API",
+    "version": "v1"
+  },
+  "tags": [
+    {
+      "name": "routes",
+      "description": "Projects service endpoints"
+    }
+  ],
+  "openapi": "3.0.3",
+  "components": {
+    "schemas": {
+      "Error": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "integer",
+            "description": "Error code"
+          },
+          "status": {
+            "type": "string",
+            "description": "Error name"
+          },
+          "message": {
+            "type": "string",
+            "description": "Error message"
+          },
+          "errors": {
+            "type": "object",
+            "description": "Errors",
+            "additionalProperties": {}
+          }
+        },
+        "additionalProperties": false
+      },
+      "PaginationMetadata": {
+        "type": "object",
+        "properties": {
+          "total": {
+            "type": "integer",
+            "description": "Total number of items."
+          },
+          "total_pages": {
+            "type": "integer",
+            "description": "Total number of pages."
+          },
+          "first_page": {
+            "type": "integer",
+            "description": "First available page number."
+          },
+          "last_page": {
+            "type": "integer",
+            "description": "Last available page number."
+          },
+          "page": {
+            "type": "integer",
+            "description": "Current page number."
+          },
+          "previous_page": {
+            "type": "integer",
+            "description": "Previous page number."
+          },
+          "next_page": {
+            "type": "integer",
+            "description": "Next page number."
+          }
+        },
+        "additionalProperties": false
+      },
+      "ProjectCreate": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "name"
+        ],
+        "additionalProperties": false
+      },
+      "Project": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "owner_user_id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "owner_user_id"
+        ],
+        "additionalProperties": false
+      },
+      "ProjectResults": {
+        "type": "object",
+        "properties": {
+          "results": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/Project"
+            }
+          }
+        },
+        "additionalProperties": false
+      },
+      "Error1": {
+        "type": "object",
+        "properties": {
+          "error": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "error"
+        ],
+        "additionalProperties": false
+      },
+      "ProjectUpdate": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "responses": {
+      "DEFAULT_ERROR": {
+        "description": "Default error response",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      },
+      "UNPROCESSABLE_ENTITY": {
+        "description": "Unprocessable Entity",
+        "content": {
+          "application/json": {
+            "schema": {
+              "$ref": "#/components/schemas/Error"
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/services/projects/requirements.txt
+++ b/services/projects/requirements.txt
@@ -2,3 +2,5 @@ Flask==3.1.3
 flask-sqlalchemy
 flask-migrate
 psycopg2-binary
+flask-smorest
+marshmallow

--- a/services/projects/scripts/generate_api_docs.py
+++ b/services/projects/scripts/generate_api_docs.py
@@ -1,0 +1,149 @@
+import json
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+OPENAPI_URL = "http://localhost:5000/openapi.json"
+OPENAPI_PATH = Path("services/projects/docs/openapi.json")
+MARKDOWN_PATH = Path("services/projects/docs/API.md")
+
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Fetch OpenAPI spec
+# ---------------------------------------------------------------------------------------------------------------------
+def fetch_openapi_spec():
+    """Fetch OpenAPI JSON from the running Flask container.
+
+    return: Parsed OpenAPI specification dictionary.
+    raises RuntimeError: If the Flask server cannot be reached.
+    """
+    try:
+        with urllib.request.urlopen(OPENAPI_URL, timeout=5) as response:
+            data = response.read()
+            print(f"Fetched OpenAPI spec from {OPENAPI_URL}")
+            return json.loads(data)
+
+    except urllib.error.URLError as exc:
+        raise RuntimeError(
+            "\nCould not fetch the OpenAPI spec.\n\n"
+            f"Tried: {OPENAPI_URL}\n\n"
+            "Make sure the projects Flask container is running and that the port is exposed.\n\n"
+            "Example:\n"
+            "  docker compose up projects\n\n"
+            "Then try again:\n"
+            "  python scripts/generate_api_docs.py\n"
+        ) from exc
+
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Save OpenAPI JSON
+# ---------------------------------------------------------------------------------------------------------------------
+def save_openapi_json(spec):
+    """Save OpenAPI spec to docs/openapi.json.
+
+    param spec: Parsed OpenAPI specification dictionary.
+    return: None.
+    """
+    OPENAPI_PATH.parent.mkdir(parents=True, exist_ok=True)
+    OPENAPI_PATH.write_text(json.dumps(spec, indent=2), encoding="utf-8")
+    print("Saved docs/openapi.json")
+
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Generate Markdown API docs
+# ---------------------------------------------------------------------------------------------------------------------
+def generate_api_md(spec):
+    """Generate a human-readable API.md from OpenAPI spec.
+
+    param spec: Parsed OpenAPI specification dictionary.
+    return: None.
+    """
+    title = spec["info"]["title"]
+    version = spec["info"]["version"]
+    paths = spec["paths"]
+
+    lines = [
+        f"# {title}",
+        "",
+        f"Version: `{version}`",
+        "",
+        "Base URL:",
+        "",
+        "```text",
+        "/api",
+        "```",
+        "",
+        "Swagger UI:",
+        "",
+        "```text",
+        "/docs",
+        "```",
+        "",
+        "## Authentication",
+        "",
+        "Project endpoints require:",
+        "",
+        "```text",
+        "X-User-ID: <user-id>",
+        "```",
+        "",
+        "## Endpoints",
+        "",
+        "| Method | Path | Description | Auth |",
+        "|---|---|---|---|",
+    ]
+
+    for path, methods in paths.items():
+        for method, details in methods.items():
+            if method == "parameters":
+                continue
+
+            summary = details.get("summary", "")
+            parameters = details.get("parameters", [])
+
+            requires_auth = any(parameter.get("name") == "X-User-ID" for parameter in parameters)
+            auth = "Yes" if requires_auth else "No"
+
+            lines.append(f"| {method.upper()} | `{path}` | {summary} | {auth} |")
+
+    lines.extend(
+        [
+            "",
+            "## Error responses",
+            "",
+            "| Status | Meaning |",
+            "|---|---|",
+            "| 400 | Bad request, such as missing `X-User-ID` |",
+            "| 404 | Resource not found |",
+            "| 422 | Request body validation failed |",
+            "",
+        ]
+    )
+
+    MARKDOWN_PATH.parent.mkdir(parents=True, exist_ok=True)
+    MARKDOWN_PATH.write_text("\n".join(lines), encoding="utf-8")
+    print("Saved docs/API.md")
+
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------------------------------------------------
+def main():
+    """Generate OpenAPI JSON and Markdown API documentation.
+
+    return: None.
+    """
+    try:
+        spec = fetch_openapi_spec()
+    except RuntimeError as exc:
+        print(exc)
+        return
+
+    save_openapi_json(spec)
+    generate_api_md(spec)
+
+    print("\nAPI documentation generated successfully")
+
+
+if __name__ == "__main__":
+    main()

--- a/services/projects/tests/test_health.py
+++ b/services/projects/tests/test_health.py
@@ -1,11 +1,11 @@
 def test_health_endpoint_returns_200(client):
-    response = client.get("/health")
+    response = client.get("/api/health")
 
     assert response.status_code == 200
 
 
 def test_health_endpoint_returns_expected_body(client):
-    response = client.get("/health")
+    response = client.get("/api/health")
 
     assert response.get_json() == {"status": "ok"}
 
@@ -13,7 +13,7 @@ def test_health_endpoint_returns_expected_body(client):
 def test_db_health_endpoint_returns_200(app):
 
     with app.test_client() as client:
-        response = client.get("/db-health")
+        response = client.get("/api/db-health")
 
     assert response.status_code == 200
     assert response.get_json() == {"database": "ok"}

--- a/services/projects/tests/test_projects_api.py
+++ b/services/projects/tests/test_projects_api.py
@@ -22,9 +22,9 @@ def get_first_result(response):
     return get_response_data(response)["results"][0]
 
 
-# -----------------------------------------------------------------
+# ---------------------------------------------------------------------------------------------------------------------
 # PROJECT CREATE TESTS
-# -----------------------------------------------------------------
+# ---------------------------------------------------------------------------------------------------------------------
 
 
 def test_create_project_success(app, client):
@@ -33,7 +33,7 @@ def test_create_project_success(app, client):
         "description": "My first project",
     }
 
-    response = client.post("/projects", json=payload, headers=USER_HEADERS)
+    response = client.post("/api/projects", json=payload, headers=USER_HEADERS)
 
     assert response.status_code == 201
 
@@ -58,10 +58,10 @@ def test_create_project_missing_user_header(client):
         "description": "My first project",
     }
 
-    response = client.post("/projects", json=payload)
+    response = client.post("/api/projects", json=payload)
 
     assert response.status_code == 400
-    assert get_response_data(response) == {"error": "Missing X-User-ID header"}
+    assert response.get_json()["message"] == "Missing X-User-ID header"
 
 
 def test_create_project_missing_name(client):
@@ -69,10 +69,10 @@ def test_create_project_missing_name(client):
         "description": "My first project",
     }
 
-    response = client.post("/projects", json=payload, headers=USER_HEADERS)
+    response = client.post("/api/projects", json=payload, headers=USER_HEADERS)
 
-    assert response.status_code == 400
-    assert get_response_data(response) == {"error": "Missing project name"}
+    assert response.status_code == 422
+    assert "errors" in response.get_json()
 
 
 def test_create_project_empty_name(client):
@@ -81,19 +81,19 @@ def test_create_project_empty_name(client):
         "description": "My first project",
     }
 
-    response = client.post("/projects", json=payload, headers=USER_HEADERS)
+    response = client.post("/api/projects", json=payload, headers=USER_HEADERS)
 
-    assert response.status_code == 400
-    assert get_response_data(response) == {"error": "Missing project name"}
+    assert response.status_code == 422
+    assert "errors" in response.get_json()
 
 
-# -----------------------------------------------------------------
+# ---------------------------------------------------------------------------------------------------------------------
 # PROJECT READ (LIST) TESTS
-# -----------------------------------------------------------------
+# ---------------------------------------------------------------------------------------------------------------------
 
 
 def test_get_projects_returns_empty_list(client):
-    response = client.get("/projects", headers=USER_HEADERS)
+    response = client.get("/api/projects", headers=USER_HEADERS)
 
     assert response.status_code == 200
 
@@ -108,10 +108,10 @@ def test_get_all_projects(client):
     payload_1 = {"name": "Project 1", "description": "An initial project"}
     payload_2 = {"name": "Project 2", "description": "A second project"}
 
-    client.post("/projects", json=payload_1, headers=USER_HEADERS)
-    client.post("/projects", json=payload_2, headers=USER_HEADERS)
+    client.post("/api/projects", json=payload_1, headers=USER_HEADERS)
+    client.post("/api/projects", json=payload_2, headers=USER_HEADERS)
 
-    response = client.get("/projects", headers=USER_HEADERS)
+    response = client.get("/api/projects", headers=USER_HEADERS)
 
     assert response.status_code == 200
 
@@ -127,10 +127,10 @@ def test_get_projects_limited_to_user(client):
     other_user_payload = {"name": "Other Project"}
     current_user_payload = {"name": "My Project"}
 
-    client.post("/projects", json=other_user_payload, headers=OTHER_USER_HEADERS)
-    client.post("/projects", json=current_user_payload, headers=USER_HEADERS)
+    client.post("/api/projects", json=other_user_payload, headers=OTHER_USER_HEADERS)
+    client.post("/api/projects", json=current_user_payload, headers=USER_HEADERS)
 
-    response = client.get("/projects", headers=USER_HEADERS)
+    response = client.get("/api/projects", headers=USER_HEADERS)
 
     assert response.status_code == 200
 
@@ -141,15 +141,15 @@ def test_get_projects_limited_to_user(client):
 
 
 def test_get_projects_missing_user_header(client):
-    response = client.get("/projects")
+    response = client.get("/api/projects")
 
     assert response.status_code == 400
-    assert get_response_data(response) == {"error": "Missing X-User-ID header"}
+    assert response.get_json()["message"] == "Missing X-User-ID header"
 
 
-# -----------------------------------------------------------------
+# ---------------------------------------------------------------------------------------------------------------------
 # PROJECT READ (DETAIL) TESTS
-# -----------------------------------------------------------------
+# ---------------------------------------------------------------------------------------------------------------------
 
 
 def test_get_project_detail_success(client):
@@ -158,13 +158,13 @@ def test_get_project_detail_success(client):
         "description": "Project for detail test",
     }
 
-    response = client.post("/projects", json=payload, headers=USER_HEADERS)
+    response = client.post("/api/projects", json=payload, headers=USER_HEADERS)
 
     assert response.status_code == 201
 
     project_id = get_first_result(response)["id"]
 
-    response = client.get(f"/projects/{project_id}", headers=USER_HEADERS)
+    response = client.get(f"/api/projects/{project_id}", headers=USER_HEADERS)
 
     assert response.status_code == 200
 
@@ -177,10 +177,10 @@ def test_get_project_detail_success(client):
 
 
 def test_get_project_detail_not_found(client):
-    response = client.get("/projects/999", headers=USER_HEADERS)
+    response = client.get("/api/projects/999", headers=USER_HEADERS)
 
     assert response.status_code == 404
-    assert get_response_data(response) == {"error": "Project not found"}
+    assert response.get_json()["message"] == "Project not found"
 
 
 def test_get_project_detail_other_user_returns_404(client):
@@ -189,28 +189,28 @@ def test_get_project_detail_other_user_returns_404(client):
         "description": "Project for detail test",
     }
 
-    response = client.post("/projects", json=payload, headers=USER_HEADERS)
+    response = client.post("/api/projects", json=payload, headers=USER_HEADERS)
 
     assert response.status_code == 201
 
     project_id = get_first_result(response)["id"]
 
-    response = client.get(f"/projects/{project_id}", headers={"X-User-ID": "456"})
+    response = client.get(f"/api/projects/{project_id}", headers={"X-User-ID": "456"})
 
     assert response.status_code == 404
-    assert get_response_data(response) == {"error": "Project not found"}
+    assert response.get_json()["message"] == "Project not found"
 
 
 def test_get_project_detail_missing_user_header(client):
-    response = client.get("/projects/1")
+    response = client.get("/api/projects/1")
 
     assert response.status_code == 400
-    assert get_response_data(response) == {"error": "Missing X-User-ID header"}
+    assert response.get_json()["message"] == "Missing X-User-ID header"
 
 
-# -----------------------------------------------------------------
+# ---------------------------------------------------------------------------------------------------------------------
 # PROJECT UPDATE TESTS
-# -----------------------------------------------------------------
+# ---------------------------------------------------------------------------------------------------------------------
 
 
 def test_update_project_success(client):
@@ -218,14 +218,14 @@ def test_update_project_success(client):
         "name": "Old Project",
         "description": "Old description",
     }
-    response = client.post("/projects", json=create_payload, headers=USER_HEADERS)
+    response = client.post("/api/projects", json=create_payload, headers=USER_HEADERS)
 
     assert response.status_code == 201
 
     project_id = get_first_result(response)["id"]
 
     update_payload = {"name": "Updated Project", "description": "Updated description"}
-    response = client.patch(f"/projects/{project_id}", json=update_payload, headers=USER_HEADERS)
+    response = client.patch(f"/api/projects/{project_id}", json=update_payload, headers=USER_HEADERS)
 
     assert response.status_code == 200
 
@@ -242,11 +242,11 @@ def test_update_project_partial_name_only(client):
         "name": "Old Project",
         "description": "Old description",
     }
-    response = client.post("/projects", json=create_payload, headers=USER_HEADERS)
+    response = client.post("/api/projects", json=create_payload, headers=USER_HEADERS)
     project_id = get_first_result(response)["id"]
 
     update_payload = {"name": "Updated Project"}
-    response = client.patch(f"/projects/{project_id}", json=update_payload, headers=USER_HEADERS)
+    response = client.patch(f"/api/projects/{project_id}", json=update_payload, headers=USER_HEADERS)
 
     assert response.status_code == 200
 
@@ -257,76 +257,78 @@ def test_update_project_partial_name_only(client):
 
 
 def test_update_project_missing_user_header(client):
-    response = client.patch("/projects/1", json={"name": "Updated Project"})
+    response = client.patch("/api/projects/1", json={"name": "Updated Project"})
 
     assert response.status_code == 400
-    assert get_response_data(response) == {"error": "Missing X-User-ID header"}
+    assert response.get_json()["message"] == "Missing X-User-ID header"
 
 
 def test_update_project_not_found(client):
     payload = {"name": "Updated Project"}
-    response = client.patch("/projects/999", json=payload, headers=USER_HEADERS)
+    response = client.patch("/api/projects/999", json=payload, headers=USER_HEADERS)
 
     assert response.status_code == 404
-    assert get_response_data(response) == {"error": "Project not found"}
+    assert response.get_json()["message"] == "Project not found"
 
 
 def test_update_project_other_user_returns_404(client):
     post_payload = {"name": "My Project"}
-    response = client.post("/projects", json=post_payload, headers=USER_HEADERS)
+    response = client.post("/api/projects", json=post_payload, headers=USER_HEADERS)
 
     project_id = get_first_result(response)["id"]
 
     update_payload = {"name": "Updated Project"}
-    response = client.patch(f"/projects/{project_id}", json=update_payload, headers={"X-User-ID": "999"})
+    response = client.patch(f"/api/projects/{project_id}", json=update_payload, headers={"X-User-ID": "999"})
 
     assert response.status_code == 404
-    assert get_response_data(response) == {"error": "Project not found"}
+    assert response.get_json()["message"] == "Project not found"
 
 
-# -----------------------------------------------------------------
+# ---------------------------------------------------------------------------------------------------------------------
 # PROJECT DELETE TESTS
-# -----------------------------------------------------------------
+# ---------------------------------------------------------------------------------------------------------------------
+
+
 def test_delete_project_success(client):
     payload = {"name": "Project to delete"}
-    response = client.post("/projects", json=payload, headers=USER_HEADERS)
+    response = client.post("/api/projects", json=payload, headers=USER_HEADERS)
     assert response.status_code == 201
 
     project_id = get_first_result(response)["id"]
-    response = client.delete(f"/projects/{project_id}", headers=USER_HEADERS)
+    response = client.delete(f"/api/projects/{project_id}", headers=USER_HEADERS)
     assert response.status_code == 204
 
-    response = client.get(f"/projects/{project_id}", headers=USER_HEADERS)
+    response = client.get(f"/api/projects/{project_id}", headers=USER_HEADERS)
 
     assert response.status_code == 404
 
 
 def test_delete_project_missing_user_header(client):
-    response = client.delete("/projects/1")
+    response = client.delete("/api/projects/1")
 
     assert response.status_code == 400
-    assert get_response_data(response) == {"error": "Missing X-User-ID header"}
+    assert response.get_json()["message"] == "Missing X-User-ID header"
 
 
 def test_delete_project_not_found(client):
-    response = client.delete("/projects/999", headers=USER_HEADERS)
+    response = client.delete("/api/projects/999", headers=USER_HEADERS)
 
     assert response.status_code == 404
-    assert get_response_data(response) == {"error": "Project not found"}
+    assert response.get_json()["message"] == "Project not found"
 
 
 def test_delete_project_other_user_returns_404(client):
     payload = {"name": "Project to delete"}
-    response = client.post("/projects", json=payload, headers=USER_HEADERS)
+    response = client.post("/api/projects", json=payload, headers=USER_HEADERS)
 
     assert response.status_code == 201
 
     project_id = get_first_result(response)["id"]
-    response = client.delete(f"/projects/{project_id}", headers=OTHER_USER_HEADERS)
+    response = client.delete(f"/api/projects/{project_id}", headers=OTHER_USER_HEADERS)
 
     assert response.status_code == 404
-    assert get_response_data(response) == {"error": "Project not found"}
+    assert response.get_json()["message"] == "Project not found"
 
-    response = client.get(f"/projects/{project_id}", headers=USER_HEADERS)
+    response = client.get(f"/api/projects/{project_id}", headers=USER_HEADERS)
 
     assert response.status_code == 200


### PR DESCRIPTION
## Description

Add automated API documentation generation and expose interactive API docs via /docs. This introduces both machine-readable and human-friendly API documentation for easier development and integration.

## Related Issue

Closes #34 
Closes #68

## Changes

- Added /docs endpoint for Swagger UI via Flask-Smorest
- Added scripts/generate_api_docs.py to generate docs/openapi.json and docs/API.md
- Integrated OpenAPI spec generation into the service
- Introduced GitHub-friendly API.md summary generated from OpenAPI
- Updated routes to use consistent error handling via abort()
- Refactored tests to align with /api/... prefix and new error response format
- Added schema validation for project name (non-empty)

## Checklist

- [x] Tests pass
- [x] CI checks succeed
- [x] Documentation updated (if needed)
