### PR TITLE
Implemented Time-Tracking CRUD Route Endpoints.

### DIFF
--- a/services/time-tracking/app/main.py
+++ b/services/time-tracking/app/main.py
@@ -29,7 +29,7 @@ def init_extensions(app):
 
 def register_routes(app):
     """Register application routes."""
-    app.register_blueprint(routes)
+    app.register_blueprint(routes, url_prefix="/api")
 
 
 def create_app():

--- a/services/time-tracking/app/routes.py
+++ b/services/time-tracking/app/routes.py
@@ -68,7 +68,7 @@ def create_time_entry():
 
 @routes.get("/time-entries")
 def list_time_entries():
-    """List all time entries."""
+    """List all time entries. Can be filtered by project_id if provided."""
     user_id = request.headers.get("X-User-ID")
 
     if not user_id:

--- a/services/time-tracking/app/routes.py
+++ b/services/time-tracking/app/routes.py
@@ -123,3 +123,35 @@ def stop_time_entry(entry_id):
         db.session.commit()
 
     return jsonify({"results": [entry.to_dict()]}), 200
+
+
+@routes.patch("/time-entries/<int:entry_id>")
+def update_time_entry(entry_id):
+    """Update a finished time entry."""
+    user_id = request.headers.get("X-User-ID")
+
+    if not user_id:
+        return jsonify({"message": "Missing X-User-ID header"}), 400
+
+    entry = TimeEntry.query.filter_by(id=entry_id, owner_user_id=user_id).first()
+
+    if not entry:
+        return jsonify({"message": "Time entry not found"}), 404
+
+    if entry.ended_at is None:
+        return jsonify({"message": "Cannot update a running time entry"}), 409
+
+    data = request.get_json() or {}
+
+    description = data.get("description")
+    project_id = data.get("project_id")
+
+    if description is not None:
+        entry.description = description
+
+    if project_id is not None:
+        entry.project_id = project_id
+
+    db.session.commit()
+
+    return jsonify({"results": [entry.to_dict()]}), 200

--- a/services/time-tracking/app/routes.py
+++ b/services/time-tracking/app/routes.py
@@ -41,13 +41,12 @@ def db_health():
 @routes.post("/time-entries")
 def create_time_entry():
     """Create a new time entry."""
-    user_id = request.headers.get("X-User-ID")
 
+    user_id = request.headers.get("X-User-ID")
     if not user_id:
         return jsonify({"message": "Missing X-User-ID header"}), 400
 
     data = request.get_json() or {}
-
     project_id = data.get("project_id")
     description = data.get("description")
 
@@ -66,11 +65,21 @@ def create_time_entry():
 
     return jsonify({"results": [entry.to_dict()]}), 201
 
+
 @routes.get("/time-entries")
 def list_time_entries():
     """List all time entries."""
     user_id = request.headers.get("X-User-ID")
 
-    entries = TimeEntry.query.filter_by(owner_user_id=user_id).all()
+    if not user_id:
+        return jsonify({"message": "Missing X-User-ID header"}), 400
+
+    query = TimeEntry.query.filter_by(owner_user_id=user_id)
+
+    project_id = request.args.get("project_id")
+    if project_id is not None:
+        query = query.filter_by(project_id=project_id)
+
+    entries = query.all()
 
     return jsonify({"results": [entry.to_dict() for entry in entries]}), 200

--- a/services/time-tracking/app/routes.py
+++ b/services/time-tracking/app/routes.py
@@ -68,7 +68,7 @@ def create_time_entry():
 
 @routes.get("/time-entries")
 def list_time_entries():
-    """List all time entries. Can be filtered by project_id if provided."""
+    """List all time entries. Can be filtered by project_id and running_only if provided."""
     user_id = request.headers.get("X-User-ID")
 
     if not user_id:
@@ -80,6 +80,25 @@ def list_time_entries():
     if project_id is not None:
         query = query.filter_by(project_id=project_id)
 
+    running_only = request.args.get("running_only")
+    if running_only == "true":
+        query = query.filter(TimeEntry.ended_at.is_(None))
+
     entries = query.all()
 
     return jsonify({"results": [entry.to_dict() for entry in entries]}), 200
+
+@routes.get("/time-entries/<int:entry_id>")
+def get_time_entry_detail(entry_id):
+    """Get a single time entry."""
+    user_id = request.headers.get("X-User-ID")
+
+    if not user_id:
+        return jsonify({"message": "Missing X-User-ID header"}), 400
+
+    entry = TimeEntry.query.filter_by(id=entry_id, owner_user_id=user_id).first()
+
+    if not entry:
+        return jsonify({"message": "Time entry not found"}), 404
+
+    return jsonify({"results": [entry.to_dict()]}), 200

--- a/services/time-tracking/app/routes.py
+++ b/services/time-tracking/app/routes.py
@@ -65,3 +65,12 @@ def create_time_entry():
     db.session.commit()
 
     return jsonify({"results": [entry.to_dict()]}), 201
+
+@routes.get("/time-entries")
+def list_time_entries():
+    """List all time entries."""
+    user_id = request.headers.get("X-User-ID")
+
+    entries = TimeEntry.query.filter_by(owner_user_id=user_id).all()
+
+    return jsonify({"results": [entry.to_dict() for entry in entries]}), 200

--- a/services/time-tracking/app/routes.py
+++ b/services/time-tracking/app/routes.py
@@ -118,8 +118,8 @@ def stop_time_entry(entry_id):
     if not entry:
         return jsonify({"message": "Time entry not found"}), 404
 
-    entry.ended_at = datetime.now(timezone.utc)
-
-    db.session.commit()
+    if entry.ended_at is None:
+        entry.ended_at = datetime.now(timezone.utc)
+        db.session.commit()
 
     return jsonify({"results": [entry.to_dict()]}), 200

--- a/services/time-tracking/app/routes.py
+++ b/services/time-tracking/app/routes.py
@@ -156,6 +156,7 @@ def update_time_entry(entry_id):
 
     return jsonify({"results": [entry.to_dict()]}), 200
 
+
 @routes.delete("/time-entries/<int:entry_id>")
 def delete_time_entry(entry_id):
     """Delete a time entry."""

--- a/services/time-tracking/app/routes.py
+++ b/services/time-tracking/app/routes.py
@@ -1,7 +1,15 @@
-from flask import Blueprint, jsonify
+from datetime import datetime, timezone
+
+from flask import Blueprint, jsonify, request
+
 from app.extensions import db
+from app.models import TimeEntry
 
 routes = Blueprint("routes", __name__)
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Helper functions for route handlers
+# ---------------------------------------------------------------------------------------------------------------------
 
 
 @routes.get("/health")
@@ -23,3 +31,37 @@ def db_health():
         connection.exec_driver_sql("SELECT 1")
 
     return jsonify({"database": "ok"}), 200
+
+
+# ---------------------------------------------------------------------------------------------------------------------
+# Route handlers
+# ---------------------------------------------------------------------------------------------------------------------
+
+
+@routes.post("/time-entries")
+def create_time_entry():
+    """Create a new time entry."""
+    user_id = request.headers.get("X-User-ID")
+
+    if not user_id:
+        return jsonify({"message": "Missing X-User-ID header"}), 400
+
+    data = request.get_json() or {}
+
+    project_id = data.get("project_id")
+    description = data.get("description")
+
+    if project_id is None:
+        return jsonify({"errors": {"project_id": "This field is required"}}), 422
+
+    entry = TimeEntry(
+        owner_user_id=user_id,
+        project_id=project_id,
+        description=description,
+        started_at=datetime.now(timezone.utc),
+    )
+
+    db.session.add(entry)
+    db.session.commit()
+
+    return jsonify({"results": [entry.to_dict()]}), 201

--- a/services/time-tracking/app/routes.py
+++ b/services/time-tracking/app/routes.py
@@ -155,3 +155,21 @@ def update_time_entry(entry_id):
     db.session.commit()
 
     return jsonify({"results": [entry.to_dict()]}), 200
+
+@routes.delete("/time-entries/<int:entry_id>")
+def delete_time_entry(entry_id):
+    """Delete a time entry."""
+    user_id = request.headers.get("X-User-ID")
+
+    if not user_id:
+        return jsonify({"message": "Missing X-User-ID header"}), 400
+
+    entry = TimeEntry.query.filter_by(id=entry_id, owner_user_id=user_id).first()
+
+    if not entry:
+        return jsonify({"message": "Time entry not found"}), 404
+
+    db.session.delete(entry)
+    db.session.commit()
+
+    return "", 204

--- a/services/time-tracking/app/routes.py
+++ b/services/time-tracking/app/routes.py
@@ -88,6 +88,7 @@ def list_time_entries():
 
     return jsonify({"results": [entry.to_dict() for entry in entries]}), 200
 
+
 @routes.get("/time-entries/<int:entry_id>")
 def get_time_entry_detail(entry_id):
     """Get a single time entry."""
@@ -100,5 +101,25 @@ def get_time_entry_detail(entry_id):
 
     if not entry:
         return jsonify({"message": "Time entry not found"}), 404
+
+    return jsonify({"results": [entry.to_dict()]}), 200
+
+
+@routes.patch("/time-entries/<int:entry_id>/stop")
+def stop_time_entry(entry_id):
+    """Stop a running time entry."""
+    user_id = request.headers.get("X-User-ID")
+
+    if not user_id:
+        return jsonify({"message": "Missing X-User-ID header"}), 400
+
+    entry = TimeEntry.query.filter_by(id=entry_id, owner_user_id=user_id).first()
+
+    if not entry:
+        return jsonify({"message": "Time entry not found"}), 404
+
+    entry.ended_at = datetime.now(timezone.utc)
+
+    db.session.commit()
 
     return jsonify({"results": [entry.to_dict()]}), 200

--- a/services/time-tracking/tests/test_health.py
+++ b/services/time-tracking/tests/test_health.py
@@ -1,11 +1,11 @@
 def test_health_endpoint_returns_200(client):
-    response = client.get("/health")
+    response = client.get("api/health")
 
     assert response.status_code == 200
 
 
 def test_health_endpoint_returns_expected_body(client):
-    response = client.get("/health")
+    response = client.get("api/health")
 
     assert response.get_json() == {"status": "ok"}
 
@@ -13,7 +13,7 @@ def test_health_endpoint_returns_expected_body(client):
 def test_db_health_endpoint_returns_200(app):
 
     with app.test_client() as client:
-        response = client.get("/db-health")
+        response = client.get("api/db-health")
 
     assert response.status_code == 200
     assert response.get_json() == {"database": "ok"}

--- a/services/time-tracking/tests/test_time_tracking_api.py
+++ b/services/time-tracking/tests/test_time_tracking_api.py
@@ -23,7 +23,6 @@ def test_create_time_entry_success(app, client):
         "project_id": 1,
         "description": "Initial work session",
     }
-
     response = client.post("/api/time-entries", json=payload, headers=USER_HEADERS)
 
     assert response.status_code == 201

--- a/services/time-tracking/tests/test_time_tracking_api.py
+++ b/services/time-tracking/tests/test_time_tracking_api.py
@@ -1,6 +1,10 @@
+from datetime import datetime, timezone
+
 from app.models import TimeEntry
+from app.extensions import db
 
 USER_HEADERS = {"X-User-ID": "123"}
+OTHER_USER_HEADERS = {"X-User-ID": "999"}
 
 
 def get_response_data(response):
@@ -112,3 +116,89 @@ def test_get_time_entries_returns_empty_list(client):
     assert "results" in data
     assert isinstance(data["results"], list)
     assert len(data["results"]) == 0
+
+
+def test_get_all_time_entries(client):
+    payload_1 = {"project_id": 1, "description": "Initial work session"}
+    payload_2 = {"project_id": 2, "description": "Second work session"}
+
+    client.post("/api/time-entries", json=payload_1, headers=USER_HEADERS)
+    client.post("/api/time-entries", json=payload_2, headers=USER_HEADERS)
+
+    response = client.get("/api/time-entries", headers=USER_HEADERS)
+
+    assert response.status_code == 200
+
+    entries = get_response_data(response)["results"]
+    descriptions = [entry["description"] for entry in entries]
+
+    assert len(entries) == 2
+    assert payload_1["description"] in descriptions
+    assert payload_2["description"] in descriptions
+
+
+def test_get_time_entries_limited_to_user(client):
+    other_user_payload = {"project_id": 1, "description": "Other user session"}
+    current_user_payload = {"project_id": 1, "description": "Current user session"}
+
+    client.post("/api/time-entries", json=other_user_payload, headers=OTHER_USER_HEADERS)
+    client.post("/api/time-entries", json=current_user_payload, headers=USER_HEADERS)
+
+    response = client.get("/api/time-entries", headers=USER_HEADERS)
+
+    assert response.status_code == 200
+
+    entries = get_response_data(response)["results"]
+
+    assert len(entries) == 1
+    assert entries[0]["description"] == current_user_payload["description"]
+
+
+def test_get_time_entries_missing_user_header(client):
+    response = client.get("/api/time-entries")
+
+    assert response.status_code == 400
+    assert response.get_json()["message"] == "Missing X-User-ID header"
+
+
+def test_get_time_entries_filtered_by_project_id(client):
+    payload_1 = {"project_id": 1, "description": "Project one session"}
+    payload_2 = {"project_id": 2, "description": "Project two session"}
+
+    client.post("/api/time-entries", json=payload_1, headers=USER_HEADERS)
+    client.post("/api/time-entries", json=payload_2, headers=USER_HEADERS)
+
+    response = client.get("/api/time-entries?project_id=2", headers=USER_HEADERS)
+
+    assert response.status_code == 200
+
+    entries = get_response_data(response)["results"]
+
+    assert len(entries) == 1
+    assert entries[0]["project_id"] == 2
+    assert entries[0]["description"] == payload_2["description"]
+
+
+def test_get_time_entries_filtered_by_running_only(app, client):
+    running_payload = {"project_id": 1, "description": "Running session"}
+    stopped_payload = {"project_id": 1, "description": "Stopped session"}
+
+    running_response = client.post("/api/time-entries", json=running_payload, headers=USER_HEADERS)
+    stopped_response = client.post("/api/time-entries", json=stopped_payload, headers=USER_HEADERS)
+
+    stopped_entry_id = get_first_result(stopped_response)["id"]
+
+    with app.app_context():
+        stopped_entry = TimeEntry.query.get(stopped_entry_id)
+        stopped_entry.ended_at = datetime.now(timezone.utc)
+        db.session.commit()
+
+    response = client.get("/api/time-entries?running_only=true", headers=USER_HEADERS)
+
+    assert response.status_code == 200
+
+    entries = get_response_data(response)["results"]
+
+    assert len(entries) == 1
+    assert entries[0]["id"] == get_first_result(running_response)["id"]
+    assert entries[0]["ended_at"] is None

--- a/services/time-tracking/tests/test_time_tracking_api.py
+++ b/services/time-tracking/tests/test_time_tracking_api.py
@@ -441,3 +441,28 @@ def test_update_time_entry_missing_user_header(client):
 
     assert response.status_code == 400
     assert response.get_json()["message"] == "Missing X-User-ID header"
+
+# ---------------------------------------------------------------------------------------------------------------------
+# TIME ENTRY DELETE TESTS
+# ---------------------------------------------------------------------------------------------------------------------
+
+
+def test_delete_time_entry_success(client):
+    payload = {
+        "project_id": 1,
+        "description": "Delete test session",
+    }
+
+    response = client.post("/api/time-entries", json=payload, headers=USER_HEADERS)
+
+    assert response.status_code == 201
+
+    entry_id = get_first_result(response)["id"]
+
+    response = client.delete(f"/api/time-entries/{entry_id}", headers=USER_HEADERS)
+
+    assert response.status_code == 204
+
+    response = client.get(f"/api/time-entries/{entry_id}", headers=USER_HEADERS)
+
+    assert response.status_code == 404

--- a/services/time-tracking/tests/test_time_tracking_api.py
+++ b/services/time-tracking/tests/test_time_tracking_api.py
@@ -95,3 +95,20 @@ def test_create_time_entry_optional_description(client):
 
     assert entry_data["project_id"] == payload["project_id"]
     assert entry_data["description"] is None
+
+
+# ---------------------------------------------------------------------------------------------------------------------
+# TIME ENTRY READ (LIST) TESTS
+# ---------------------------------------------------------------------------------------------------------------------
+
+
+def test_get_time_entries_returns_empty_list(client):
+    response = client.get("/api/time-entries", headers=USER_HEADERS)
+
+    assert response.status_code == 200
+
+    data = get_response_data(response)
+
+    assert "results" in data
+    assert isinstance(data["results"], list)
+    assert len(data["results"]) == 0

--- a/services/time-tracking/tests/test_time_tracking_api.py
+++ b/services/time-tracking/tests/test_time_tracking_api.py
@@ -203,6 +203,7 @@ def test_get_time_entries_filtered_by_running_only(app, client):
     assert entries[0]["id"] == get_first_result(running_response)["id"]
     assert entries[0]["ended_at"] is None
 
+
 # ---------------------------------------------------------------------------------------------------------------------
 # TIME ENTRY READ (DETAIL) TESTS
 # ---------------------------------------------------------------------------------------------------------------------
@@ -232,3 +233,35 @@ def test_get_time_entry_detail_success(client):
     assert entry_data["owner_user_id"] == USER_HEADERS["X-User-ID"]
     assert entry_data["started_at"] is not None
     assert entry_data["ended_at"] is None
+
+
+def test_get_time_entry_detail_not_found(client):
+    response = client.get("/api/time-entries/999", headers=USER_HEADERS)
+
+    assert response.status_code == 404
+    assert response.get_json()["message"] == "Time entry not found"
+
+
+def test_get_time_entry_detail_other_user_returns_404(client):
+    payload = {
+        "project_id": 1,
+        "description": "Other user detail test",
+    }
+
+    response = client.post("/api/time-entries", json=payload, headers=USER_HEADERS)
+
+    assert response.status_code == 201
+
+    entry_id = get_first_result(response)["id"]
+
+    response = client.get(f"/api/time-entries/{entry_id}", headers=OTHER_USER_HEADERS)
+
+    assert response.status_code == 404
+    assert response.get_json()["message"] == "Time entry not found"
+
+
+def test_get_time_entry_detail_missing_user_header(client):
+    response = client.get("/api/time-entries/1")
+
+    assert response.status_code == 400
+    assert response.get_json()["message"] == "Missing X-User-ID header"

--- a/services/time-tracking/tests/test_time_tracking_api.py
+++ b/services/time-tracking/tests/test_time_tracking_api.py
@@ -442,6 +442,7 @@ def test_update_time_entry_missing_user_header(client):
     assert response.status_code == 400
     assert response.get_json()["message"] == "Missing X-User-ID header"
 
+
 # ---------------------------------------------------------------------------------------------------------------------
 # TIME ENTRY DELETE TESTS
 # ---------------------------------------------------------------------------------------------------------------------
@@ -466,6 +467,7 @@ def test_delete_time_entry_success(client):
     response = client.get(f"/api/time-entries/{entry_id}", headers=USER_HEADERS)
 
     assert response.status_code == 404
+
 
 def test_delete_time_entry_missing_user_header(client):
     response = client.delete("/api/time-entries/1")

--- a/services/time-tracking/tests/test_time_tracking_api.py
+++ b/services/time-tracking/tests/test_time_tracking_api.py
@@ -389,3 +389,55 @@ def test_update_time_entry_success(client):
     assert entry_data["description"] == update_payload["description"]
     assert entry_data["project_id"] == payload["project_id"]
     assert entry_data["owner_user_id"] == USER_HEADERS["X-User-ID"]
+
+
+def test_update_time_entry_running_entry_returns_409(client):
+    payload = {
+        "project_id": 1,
+        "description": "Running session",
+    }
+
+    response = client.post("/api/time-entries", json=payload, headers=USER_HEADERS)
+    entry_id = get_first_result(response)["id"]
+
+    update_payload = {"description": "Should not update"}
+
+    response = client.patch(f"/api/time-entries/{entry_id}", json=update_payload, headers=USER_HEADERS)
+
+    assert response.status_code == 409
+    assert response.get_json()["message"] == "Cannot update a running time entry"
+
+
+def test_update_time_entry_not_found(client):
+    payload = {"description": "Updated"}
+
+    response = client.patch("/api/time-entries/999", json=payload, headers=USER_HEADERS)
+
+    assert response.status_code == 404
+    assert response.get_json()["message"] == "Time entry not found"
+
+
+def test_update_time_entry_other_user_returns_404(client):
+    payload = {
+        "project_id": 1,
+        "description": "User test",
+    }
+
+    response = client.post("/api/time-entries", json=payload, headers=USER_HEADERS)
+    entry_id = get_first_result(response)["id"]
+
+    client.patch(f"/api/time-entries/{entry_id}/stop", headers=USER_HEADERS)
+
+    update_payload = {"description": "Updated"}
+
+    response = client.patch(f"/api/time-entries/{entry_id}", json=update_payload, headers=OTHER_USER_HEADERS)
+
+    assert response.status_code == 404
+    assert response.get_json()["message"] == "Time entry not found"
+
+
+def test_update_time_entry_missing_user_header(client):
+    response = client.patch("/api/time-entries/1", json={"description": "Updated"})
+
+    assert response.status_code == 400
+    assert response.get_json()["message"] == "Missing X-User-ID header"

--- a/services/time-tracking/tests/test_time_tracking_api.py
+++ b/services/time-tracking/tests/test_time_tracking_api.py
@@ -353,3 +353,39 @@ def test_stop_time_entry_missing_user_header(client):
 
     assert response.status_code == 400
     assert response.get_json()["message"] == "Missing X-User-ID header"
+
+
+# ---------------------------------------------------------------------------------------------------------------------
+# TIME ENTRY UPDATE TESTS
+# ---------------------------------------------------------------------------------------------------------------------
+
+
+def test_update_time_entry_success(client):
+    payload = {
+        "project_id": 1,
+        "description": "Initial session",
+    }
+
+    response = client.post("/api/time-entries", json=payload, headers=USER_HEADERS)
+
+    assert response.status_code == 201
+
+    entry_id = get_first_result(response)["id"]
+
+    # Stop the entry first (updates only allowed on finished entries)
+    client.patch(f"/api/time-entries/{entry_id}/stop", headers=USER_HEADERS)
+
+    update_payload = {
+        "description": "Updated session description",
+    }
+
+    response = client.patch(f"/api/time-entries/{entry_id}", json=update_payload, headers=USER_HEADERS)
+
+    assert response.status_code == 200
+
+    entry_data = get_first_result(response)
+
+    assert entry_data["id"] == entry_id
+    assert entry_data["description"] == update_payload["description"]
+    assert entry_data["project_id"] == payload["project_id"]
+    assert entry_data["owner_user_id"] == USER_HEADERS["X-User-ID"]

--- a/services/time-tracking/tests/test_time_tracking_api.py
+++ b/services/time-tracking/tests/test_time_tracking_api.py
@@ -466,3 +466,38 @@ def test_delete_time_entry_success(client):
     response = client.get(f"/api/time-entries/{entry_id}", headers=USER_HEADERS)
 
     assert response.status_code == 404
+
+def test_delete_time_entry_missing_user_header(client):
+    response = client.delete("/api/time-entries/1")
+
+    assert response.status_code == 400
+    assert response.get_json()["message"] == "Missing X-User-ID header"
+
+
+def test_delete_time_entry_not_found(client):
+    response = client.delete("/api/time-entries/999", headers=USER_HEADERS)
+
+    assert response.status_code == 404
+    assert response.get_json()["message"] == "Time entry not found"
+
+
+def test_delete_time_entry_other_user_returns_404(client):
+    payload = {
+        "project_id": 1,
+        "description": "Other user delete test",
+    }
+
+    response = client.post("/api/time-entries", json=payload, headers=USER_HEADERS)
+
+    assert response.status_code == 201
+
+    entry_id = get_first_result(response)["id"]
+
+    response = client.delete(f"/api/time-entries/{entry_id}", headers=OTHER_USER_HEADERS)
+
+    assert response.status_code == 404
+    assert response.get_json()["message"] == "Time entry not found"
+
+    response = client.get(f"/api/time-entries/{entry_id}", headers=USER_HEADERS)
+
+    assert response.status_code == 200

--- a/services/time-tracking/tests/test_time_tracking_api.py
+++ b/services/time-tracking/tests/test_time_tracking_api.py
@@ -1,0 +1,49 @@
+from app.models import TimeEntry
+
+USER_HEADERS = {"X-User-ID": "123"}
+
+
+def get_response_data(response):
+    """Return JSON response data."""
+    return response.get_json()
+
+
+def get_first_result(response):
+    """Return the first item from a results response."""
+    return get_response_data(response)["results"][0]
+
+
+# ---------------------------------------------------------------------------------------------------------------------
+# TIME ENTRY CREATE TESTS
+# ---------------------------------------------------------------------------------------------------------------------
+
+
+def test_create_time_entry_success(app, client):
+    payload = {
+        "project_id": 1,
+        "description": "Initial work session",
+    }
+
+    response = client.post("/api/time-entries", json=payload, headers=USER_HEADERS)
+
+    assert response.status_code == 201
+
+    entry_data = get_first_result(response)
+
+    assert entry_data["id"] is not None
+    assert entry_data["project_id"] == payload["project_id"]
+    assert entry_data["description"] == payload["description"]
+    assert entry_data["owner_user_id"] == USER_HEADERS["X-User-ID"]
+
+    assert entry_data["started_at"] is not None
+    assert entry_data["ended_at"] is None
+    assert entry_data["duration_seconds"] is None
+
+    with app.app_context():
+        entry = TimeEntry.query.filter_by(owner_user_id=USER_HEADERS["X-User-ID"]).first()
+
+    assert entry is not None
+    assert entry.project_id == payload["project_id"]
+    assert entry.description == payload["description"]
+    assert entry.ended_at is None
+

--- a/services/time-tracking/tests/test_time_tracking_api.py
+++ b/services/time-tracking/tests/test_time_tracking_api.py
@@ -46,3 +46,52 @@ def test_create_time_entry_success(app, client):
     assert entry.description == payload["description"]
     assert entry.ended_at is None
 
+
+def test_create_time_entry_missing_user_header(client):
+    payload = {
+        "project_id": 1,
+        "description": "Initial work session",
+    }
+
+    response = client.post("/api/time-entries", json=payload)
+
+    assert response.status_code == 400
+    assert response.get_json()["message"] == "Missing X-User-ID header"
+
+
+def test_create_time_entry_missing_project_id(client):
+    payload = {
+        "description": "Initial work session",
+    }
+
+    response = client.post("/api/time-entries", json=payload, headers=USER_HEADERS)
+
+    assert response.status_code == 422
+    assert "errors" in response.get_json()
+
+
+def test_create_time_entry_null_project_id(client):
+    payload = {
+        "project_id": None,
+        "description": "Initial work session",
+    }
+
+    response = client.post("/api/time-entries", json=payload, headers=USER_HEADERS)
+
+    assert response.status_code == 422
+    assert "errors" in response.get_json()
+
+
+def test_create_time_entry_optional_description(client):
+    payload = {
+        "project_id": 1,
+    }
+
+    response = client.post("/api/time-entries", json=payload, headers=USER_HEADERS)
+
+    assert response.status_code == 201
+
+    entry_data = get_first_result(response)
+
+    assert entry_data["project_id"] == payload["project_id"]
+    assert entry_data["description"] is None

--- a/services/time-tracking/tests/test_time_tracking_api.py
+++ b/services/time-tracking/tests/test_time_tracking_api.py
@@ -265,3 +265,30 @@ def test_get_time_entry_detail_missing_user_header(client):
 
     assert response.status_code == 400
     assert response.get_json()["message"] == "Missing X-User-ID header"
+
+# ---------------------------------------------------------------------------------------------------------------------
+# TIME ENTRY STOP TESTS
+# ---------------------------------------------------------------------------------------------------------------------
+
+
+def test_stop_time_entry_success(client):
+    payload = {
+        "project_id": 1,
+        "description": "Stop test session",
+    }
+
+    response = client.post("/api/time-entries", json=payload, headers=USER_HEADERS)
+
+    assert response.status_code == 201
+
+    entry_id = get_first_result(response)["id"]
+
+    response = client.patch(f"/api/time-entries/{entry_id}/stop", headers=USER_HEADERS)
+
+    assert response.status_code == 200
+
+    entry_data = get_first_result(response)
+
+    assert entry_data["id"] == entry_id
+    assert entry_data["ended_at"] is not None
+    assert entry_data["duration_seconds"] is not None

--- a/services/time-tracking/tests/test_time_tracking_api.py
+++ b/services/time-tracking/tests/test_time_tracking_api.py
@@ -266,6 +266,7 @@ def test_get_time_entry_detail_missing_user_header(client):
     assert response.status_code == 400
     assert response.get_json()["message"] == "Missing X-User-ID header"
 
+
 # ---------------------------------------------------------------------------------------------------------------------
 # TIME ENTRY STOP TESTS
 # ---------------------------------------------------------------------------------------------------------------------
@@ -292,3 +293,63 @@ def test_stop_time_entry_success(client):
     assert entry_data["id"] == entry_id
     assert entry_data["ended_at"] is not None
     assert entry_data["duration_seconds"] is not None
+
+
+def test_stop_time_entry_already_stopped(client):
+    payload = {
+        "project_id": 1,
+        "description": "Already stopped session",
+    }
+
+    response = client.post("/api/time-entries", json=payload, headers=USER_HEADERS)
+
+    assert response.status_code == 201
+
+    entry_id = get_first_result(response)["id"]
+
+    response = client.patch(f"/api/time-entries/{entry_id}/stop", headers=USER_HEADERS)
+
+    assert response.status_code == 200
+
+    first_ended_at = get_first_result(response)["ended_at"]
+
+    response = client.patch(f"/api/time-entries/{entry_id}/stop", headers=USER_HEADERS)
+
+    assert response.status_code == 200
+
+    entry_data = get_first_result(response)
+
+    assert entry_data["ended_at"] == first_ended_at
+    assert entry_data["duration_seconds"] is not None
+
+
+def test_stop_time_entry_not_found(client):
+    response = client.patch("/api/time-entries/999/stop", headers=USER_HEADERS)
+
+    assert response.status_code == 404
+    assert response.get_json()["message"] == "Time entry not found"
+
+
+def test_stop_time_entry_other_user_returns_404(client):
+    payload = {
+        "project_id": 1,
+        "description": "Other user stop test",
+    }
+
+    response = client.post("/api/time-entries", json=payload, headers=USER_HEADERS)
+
+    assert response.status_code == 201
+
+    entry_id = get_first_result(response)["id"]
+
+    response = client.patch(f"/api/time-entries/{entry_id}/stop", headers=OTHER_USER_HEADERS)
+
+    assert response.status_code == 404
+    assert response.get_json()["message"] == "Time entry not found"
+
+
+def test_stop_time_entry_missing_user_header(client):
+    response = client.patch("/api/time-entries/1/stop")
+
+    assert response.status_code == 400
+    assert response.get_json()["message"] == "Missing X-User-ID header"

--- a/services/time-tracking/tests/test_time_tracking_api.py
+++ b/services/time-tracking/tests/test_time_tracking_api.py
@@ -202,3 +202,33 @@ def test_get_time_entries_filtered_by_running_only(app, client):
     assert len(entries) == 1
     assert entries[0]["id"] == get_first_result(running_response)["id"]
     assert entries[0]["ended_at"] is None
+
+# ---------------------------------------------------------------------------------------------------------------------
+# TIME ENTRY READ (DETAIL) TESTS
+# ---------------------------------------------------------------------------------------------------------------------
+
+
+def test_get_time_entry_detail_success(client):
+    payload = {
+        "project_id": 1,
+        "description": "Detail work session",
+    }
+
+    response = client.post("/api/time-entries", json=payload, headers=USER_HEADERS)
+
+    assert response.status_code == 201
+
+    entry_id = get_first_result(response)["id"]
+
+    response = client.get(f"/api/time-entries/{entry_id}", headers=USER_HEADERS)
+
+    assert response.status_code == 200
+
+    entry_data = get_first_result(response)
+
+    assert entry_data["id"] == entry_id
+    assert entry_data["project_id"] == payload["project_id"]
+    assert entry_data["description"] == payload["description"]
+    assert entry_data["owner_user_id"] == USER_HEADERS["X-User-ID"]
+    assert entry_data["started_at"] is not None
+    assert entry_data["ended_at"] is None


### PR DESCRIPTION
## Description

Implemented basic CRUD endpoints for the Flask Time-Tracking microservice using a test-driven approach.

## Related Issue

Closes #54
Closes #55
Closes #57
Closes #59

## Changes

- Time-tracking records can be created, listed, retrieved, updated, and deleted via HTTP
- Endpoints require authenticated user context, e.g. X-User-ID
- Users can only access their own time-tracking records
- Request payloads are validated with schemas
- API responses use a consistent structure, e.g. {"results": [...]}
- Service returns appropriate status codes for success, validation errors, missing user headers, not found, and delete actions
- Unit/API tests cover happy paths, validation errors, missing user context, and user isolation
- Includes:
    - /health endpoint confirms the service is running
    - /ready endpoint confirms the service can connect to the database
    - Readiness fails if database connection is unavailable
    - Endpoints return simple JSON responses
    - sessions list only returns sessions for the current X-User-ID
    - Users cannot retrieve another user’s sessions logs
    - Users cannot update another user’s sessions logs
    - Users cannot delete another user’s sessions logs
    - Cross-user access returns an appropriate error response

## Checklist

- [x] Tests pass
- [x] CI checks succeed
- [x] Documentation updated (if needed)
