### PR TITLE
Add manual deployment trigger for CI/CD debugging

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,7 @@
 name: Deploy to AWS EC2
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -16,7 +17,7 @@ jobs:
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
-          key: ${{ secrets.EC2_SSH_KEY }}
+          key: "${{ secrets.EC2_SSH_KEY }}"
           script: |
             cd ${{ secrets.EC2_PROJECT_DIR }}
             git fetch origin main


### PR DESCRIPTION
## Description

Add manual workflow dispatch support and update the deployment workflow to aid CI/CD debugging for the AWS EC2 deployment pipeline.

## Related Issue

Closes #

## Changes

- Added `workflow_dispatch` support for manual deployment runs
- Updated GitHub Actions deployment workflow configuration
- Improved deployment debugging workflow without requiring additional commits

## Checklist

- [x] Tests pass
- [x] CI checks succeed
- [x] Documentation updated (if needed)
